### PR TITLE
use static ip's for bootstrap config

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -135,8 +135,8 @@ x-stacks-node: &stacks-node
         STACKS_LOG_JSON: *STACKS_LOG_JSON
         STACKS_LOG_DEBUG: *STACKS_LOG_DEBUG
         STACKS_LOG_FORMAT_TIME: *STACKS_LOG_FORMAT_TIME
-        BOOTSTRAP_NODE: "0383bca67d28fce336ea7c2fc1120ecc63fbe55e89251e20587c2eb877f971e56b@stacks-miner-1:20444,037f705fffab4de974d10563828ee3bf0c3e2e4f318f9ae670b8374a7b890195a2@stacks-miner-2:20444,03180a98f60f943f1594adec7cd39d639a0cc5109a33219c268c796d55096fe66b@stacks-miner-3:20444"
-        # BOOTSTRAP_NODE: "032ec5eb701cc2e01ea99f8bf4a6a5148a39018c00fa6cfe7bee4fdf0b2098e7a7@stacks-miner-1:20444,037f705fffab4de974d10563828ee3bf0c3e2e4f318f9ae670b8374a7b890195a2@stacks-miner-2:20444,03180a98f60f943f1594adec7cd39d639a0cc5109a33219c268c796d55096fe66b@stacks-miner-3:20444"
+        # Use static IP's defined above for the bootstrap nodes in case one or more miners are stopped/crashed and docker removes the DNS entry
+        BOOTSTRAP_NODE: "0383bca67d28fce336ea7c2fc1120ecc63fbe55e89251e20587c2eb877f971e56b@10.0.0.101:20444,037f705fffab4de974d10563828ee3bf0c3e2e4f318f9ae670b8374a7b890195a2@10.0.0.102:20444,03180a98f60f943f1594adec7cd39d639a0cc5109a33219c268c796d55096fe66b@10.0.0.103:20444"
     networks:
         - default
     entrypoint:


### PR DESCRIPTION
resolves #14 

replaces the dns names in teh bootstrap config with static ip's (hardcoded already in the compose file)